### PR TITLE
Remove social media buttons

### DIFF
--- a/src/components/BusinessResults.js
+++ b/src/components/BusinessResults.js
@@ -1,4 +1,3 @@
-import Socials from "../components/Socials";
 import React, { Component } from "react";
 import { addCommas, removeCommas } from '../helpers/helper-functions';
 import DonateButton from '../components/DonateButton';
@@ -99,11 +98,7 @@ class BusinessResults extends Component {
             </div>
           </div>
         )}
-        <Socials
-          imageURL={this.props.imageURL}
-          size="40"
-          killClass={this.props.killClass}
-        />
+
         <DonateButton />
       </div>
     );

--- a/src/components/IndividualResults.js
+++ b/src/components/IndividualResults.js
@@ -1,4 +1,3 @@
-import Socials from "../components/Socials";
 import DonateButton from '../components/DonateButton'
 import React, { Component } from "react";
 import { addCommas } from '../helpers/helper-functions';
@@ -65,13 +64,6 @@ class IndividualResults extends Component {
 			   </div>
             ]
 		  }
-          <Socials
-            killClass={this.props.killClass}
-            savings={this.props.savings}
-            imageURL={this.props.imageURL}
-            size="40"
-          />
-
           <DonateButton />
 
         </div>
@@ -163,13 +155,6 @@ class IndividualResults extends Component {
               </div>
             ]
           }
-          <Socials
-            killClass={this.props.killClass}
-            savings={this.props.savings}
-            imageURL={this.props.imageURL}
-            size="40"
-          />
-
           <DonateButton />
         </div>
       );


### PR DESCRIPTION
For Issue #58 

(Sorry for the duplicate.  The previous PR was polluted with merges.)

Removes the social media buttons from the results.  This change is bundled separately to make it easier to undo later.